### PR TITLE
Add support for Kerberos authentication

### DIFF
--- a/com.getferdi.Ferdi.yaml
+++ b/com.getferdi.Ferdi.yaml
@@ -18,9 +18,27 @@ finish-args:
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-videos:ro
   - --filesystem=xdg-documents:ro
+  - --filesystem=/run/.heim_org.h5l.kcm-socket
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
 modules:
+  - name: krb5
+    subdir: src
+    config-opts:
+      - --disable-static
+      - --disable-rpath
+    sources:
+      - type: archive
+        url: https://kerberos.org/dist/krb5/1.16/krb5-1.16.2.tar.gz
+        sha256: 9f721e1fe593c219174740c71de514c7228a97d23eb7be7597b2ae14e487f027
+  - name: krb5-config
+    buildsystem: simple
+    sources:
+      - type: file
+        path: krb5.conf
+    build-commands:
+        - mkdir -p /app/etc
+        - install -m 644 krb5.conf /app/etc/krb5.conf
   - name: ferdi-desktop
     buildsystem: simple
     build-commands:

--- a/krb5.conf
+++ b/krb5.conf
@@ -1,0 +1,9 @@
+[libdefaults]
+    dns_lookup_realm = false
+    ticket_lifetime = 24h
+    renew_lifetime = 7d
+    forwardable = true
+    rdns = false
+    pkinit_anchors = FILE:/etc/ssl/certs/ca-certificates.crt
+    spake_preauth_groups = edwards25519
+    default_ccache_name = KCM:


### PR DESCRIPTION
The Kerberos authentication is useful in environments (usually corporate
ones), when if properly configured it can authenticate against the
whitelisted servers and avoid using the username/password
authentication.

To use it in Ferdi, users only have to whitelist the authentication servers
by using the "--auth-server-whitelist" argument passed to the Ferdi
Flatpak[0][1].

This is inspired by [2] and [3].

[0] - https://github.com/getferdi/ferdi/blob/5d36215319d5037a38cb8b4499233465918d4523/src/index.js#L323
[1] - https://github.com/getferdi/ferdi/blob/5d36215319d5037a38cb8b4499233465918d4523/src/index.js#L320
[2] - https://gitlab.gnome.org/GNOME/epiphany/-/commit/bba622a1b92c29cad65af3ca27f4d6be55a925c9
[3] - https://gitlab.gnome.org/GNOME/gnome-build-meta/-/commit/da2bb3cefcea37065f85baf604c6d1b4f7b7ed61